### PR TITLE
Move all database access to a dedicated module.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@ dist
 .DS_Store
 .cabal-sandbox
 cabal.sandbox.config
-haddocset.hi
-haddocset.o
-haddocset
+/haddocset.hi
+/haddocset.o
+/haddocset
 *.docset

--- a/Documentation/Haddocset/Index.hs
+++ b/Documentation/Haddocset/Index.hs
@@ -1,0 +1,109 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes        #-}
+{-# LANGUAGE RecordWildCards   #-}
+module Documentation.Haddocset.Index
+    ( SearchIndex
+    , ReadWrite
+    , ReadOnly
+
+    , EntryType(..)
+    , IndexEntry(..)
+
+    , withSearchIndex
+    , withReadWrite
+    , insert
+    , sinkEntries
+    ) where
+
+
+import Data.Text            (Text)
+import Distribution.Package (PackageId)
+import Distribution.Text    (display)
+
+import qualified Data.Conduit                   as C
+import qualified Data.Conduit.List              as CL
+import qualified Database.SQLite.Simple         as Sql
+import qualified Database.SQLite.Simple.ToField as Sql
+import qualified Filesystem.Path.CurrentOS      as P
+
+data ReadWrite
+
+data ReadOnly
+
+-- | A handle to a docset search index.
+--
+-- This will be tagged with 'ReadWrite' or 'ReadOnly'.
+newtype SearchIndex a = SearchIndex Sql.Connection
+
+data EntryType
+    = PackageEntry
+    | ModuleEntry
+    | TypeEntry
+    | ConstructorEntry
+    | FunctionEntry
+  deriving (Show, Ord, Eq)
+
+instance Sql.ToField EntryType where
+    toField PackageEntry = Sql.SQLText "Package"
+    toField ModuleEntry = Sql.SQLText "Module"
+    toField TypeEntry = Sql.SQLText "Type"
+    toField ConstructorEntry = Sql.SQLText "Constructor"
+    toField FunctionEntry = Sql.SQLText "Function"
+
+
+-- | An entry in the search index.
+data IndexEntry = IndexEntry
+    { entryName    :: !Text
+    , entryType    :: !EntryType
+    , entryPath    :: !String
+    , entryPackage :: !PackageId
+    } deriving (Show, Ord, Eq)
+
+instance Sql.ToRow IndexEntry where
+    toRow IndexEntry{..} =
+        Sql.toRow (entryName, entryType, entryPath, display entryPackage)
+
+-- | Executes the given operation on the search index at the specified
+-- location.
+withSearchIndex :: P.FilePath -> (SearchIndex ReadOnly -> IO a) -> IO a
+withSearchIndex path f =
+    Sql.withConnection (P.encodeString path) $ \conn -> do
+        Sql.execute_ conn
+            "CREATE TABLE IF NOT EXISTS searchIndex \
+                \ ( id INTEGER PRIMARY KEY \
+                \ , name TEXT \
+                \ , type TEXT \
+                \ , path TEXT \
+                \ , package TEXT \
+                \ )"
+
+        Sql.execute_ conn
+          "CREATE UNIQUE INDEX IF NOT EXISTS \
+                \ anchor ON searchIndex (name, type, path, package)"
+
+        f (SearchIndex conn)
+
+
+-- | Executes an operation on a 'ReadWrite' SearchIndex.
+--
+-- Opens a database transaction. If the operation fails for any reason, the
+-- changes are rolled back.
+withReadWrite :: SearchIndex ReadOnly -> (SearchIndex ReadWrite -> IO a) -> IO a
+withReadWrite (SearchIndex conn) f =
+    Sql.withTransaction conn $
+        f (SearchIndex conn)
+
+-- | Inserts an item into a SearchIndex.
+insert :: SearchIndex ReadWrite -> IndexEntry -> IO ()
+insert (SearchIndex conn) = Sql.execute conn insertStmt
+
+
+insertStmt :: Sql.Query
+insertStmt =
+    "INSERT OR IGNORE INTO searchIndex \
+        \ (name, type, path,package) VALUES (?, ?, ?, ?)"
+
+
+-- | A sink to write index entries.
+sinkEntries :: SearchIndex ReadWrite -> C.Consumer IndexEntry IO ()
+sinkEntries searchIndex = CL.mapM_ (insert searchIndex)

--- a/Documentation/Haddocset/Plist.hs
+++ b/Documentation/Haddocset/Plist.hs
@@ -1,0 +1,37 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards   #-}
+module Documentation.Haddocset.Plist
+    ( Plist(..)
+    , showPlist
+    ) where
+
+import Data.Monoid
+import Data.Text   (Text)
+
+import qualified Data.Text as T
+
+data Plist = Plist
+    { cfBundleIdentifier   :: Text
+    , cfBundleName         :: Text
+    , docSetPlatformFamily :: Text
+    } deriving Show
+
+showPlist :: Plist -> Text
+showPlist Plist{..} = T.unlines
+    [ "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+    , "<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">"
+    , "<plist version=\"1.0\">"
+    , "<dict>"
+    , "<key>CFBundleIdentifier</key>"
+    , "<string>" <> cfBundleIdentifier <> "</string>"
+    , "<key>CFBundleName</key>"
+    , "<string>" <> cfBundleName <> "</string>"
+    , "<key>DocSetPlatformFamily</key>"
+    , "<string>" <> docSetPlatformFamily <> "</string>"
+    , "<key>isDashDocset</key>"
+    , "<true/>"
+    , "<key>dashIndexFilePath</key>"
+    , "<string>index.html</string>"
+    , "</dict>"
+    , "</plist>"
+    ]

--- a/Main.hs
+++ b/Main.hs
@@ -11,7 +11,7 @@ import qualified Filesystem.Path.CurrentOS as P
 
 import           System.IO.Error
 
-import qualified Database.SQLite.Simple    as Sql
+import qualified Data.Text                 as T
 
 import           Data.Maybe
 
@@ -19,21 +19,22 @@ import           Data.Maybe
 import           Options.Applicative
 
 import           Documentation.Haddocset
+import           Documentation.Haddocset.Index
+import           Documentation.Haddocset.Plist
 
 createCommand :: Options -> IO ()
 createCommand o = do
-    unless (optQuiet o) $ putStrLn "[1/5] Create Directory."
-    P.createDirectory False (optTarget o) -- for fail when directory already exists.
-    P.createTree           (optDocumentsDir o)
-    P.createDirectory True (optHaddockDir o)
+  unless (optQuiet o) $ putStrLn "[1/5] Create Directory."
+  P.createDirectory False (optTarget o) -- for fail when directory already exists.
+  P.createTree           (optDocumentsDir o)
+  P.createDirectory True (optHaddockDir o)
 
-    unless (optQuiet o) $ putStrLn "[2/5] Writing plist."
-    writeFile (P.encodeString $ optTarget o P.</> "Contents/Info.plist") $ showPlist (createPlist $ optCommand o)
+  unless (optQuiet o) $ putStrLn "[2/5] Writing plist."
+  P.writeTextFile (optTarget o P.</> "Contents/Info.plist") $
+        showPlist (createPlist $ optCommand o)
 
-    unless (optQuiet o) $ putStrLn "[3/5] Migrate Database."
-    conn <- Sql.open . P.encodeString $ optTarget o P.</> "Contents/Resources/docSet.dsidx"
-    Sql.execute_ conn "CREATE TABLE searchIndex(id INTEGER PRIMARY KEY, name TEXT, type TEXT, path TEXT, package TEXT);"
-    Sql.execute_ conn "CREATE UNIQUE INDEX anchor ON searchIndex (name, type, path, package);"
+  unless (optQuiet o) $ putStrLn "[3/5] Migrate Database."
+  withSearchIndex (optTarget o P.</> "Contents/Resources/docSet.dsidx") $ \idx -> do
 
     globalDirs <- globalPackageDirectories (optHcPkg o)
     unless (optQuiet o) $ do
@@ -48,21 +49,22 @@ createCommand o = do
     unless (optQuiet o) $ putStr "    Global package count:     " >> print (length globals)
 
     unless (optQuiet o) $ putStrLn "[4/5] Copy and populate Documents."
-    forM_ iFiles $ \iFile -> addSinglePackage (optQuiet o) False (optDocumentsDir o) (optHaddockDir o) conn iFile
+    forM_ iFiles $ \iFile ->
+        addSinglePackage (optQuiet o) False (optDocumentsDir o) (optHaddockDir o) idx iFile
 
     unless (optQuiet o) $ putStrLn "[5/5] Create index."
     haddockIndex (optHaddockDir o) (optDocumentsDir o)
 
 addCommand :: Options -> Bool -> IO ()
-addCommand o force = do
-    conn <- Sql.open . P.encodeString $ optTarget o P.</> "Contents/Resources/docSet.dsidx"
-    forM_ (toAddFiles $ optCommand o) $ \i -> go conn i
-        `catchIOError` handler
+addCommand o force =
+  withSearchIndex (optTarget o P.</> "Contents/Resources/docSet.dsidx") $ \idx -> do
+    forM_ (toAddFiles $ optCommand o) $ \i ->
+        go idx i `catchIOError` handler
     haddockIndex (optHaddockDir o) (optDocumentsDir o)
   where
-    go conn p = readDocInfoFile p >>= \mbIFile -> case mbIFile of
+    go idx p = readDocInfoFile p >>= \mbIFile -> case mbIFile of
         Nothing    -> return ()
-        Just iFile -> addSinglePackage (optQuiet o) force (optDocumentsDir o) (optHaddockDir o) conn iFile
+        Just iFile -> addSinglePackage (optQuiet o) force (optDocumentsDir o) (optHaddockDir o) idx iFile
     handler ioe
             | isDoesNotExistError ioe = print   ioe
             | otherwise               = ioError ioe
@@ -108,11 +110,13 @@ main = do
                     <> command "add"    (info addOpts $ progDesc "add package to docset."))
 
     createOpts = Create
-        <$> ( Plist <$> (strOption (long "CFBundleIdentifier")   <|> pure "haskell")
-                    <*> (strOption (long "CFBundleName")         <|> pure "Haskell")
-                    <*> (strOption (long "DocSetPlatformFamily") <|> pure "haskell"))
+        <$> ( Plist <$> (textOption (long "CFBundleIdentifier")   <|> pure "haskell")
+                    <*> (textOption (long "CFBundleName")         <|> pure "Haskell")
+                    <*> (textOption (long "DocSetPlatformFamily") <|> pure "haskell"))
         <*> many (argument (P.decodeString <$> str) (metavar "CONFS" <> help "path to installed package configuration."))
 
     addOpts = Add
         <$> some (argument (P.decodeString <$> str) (metavar "CONFS" <> help "path to installed package configuration."))
         <*> switch (long "force" <> short 'f' <> help "overwrite exist package.")
+
+    textOption = fmap T.pack . strOption

--- a/haddocset.cabal
+++ b/haddocset.cabal
@@ -15,7 +15,10 @@ cabal-version:       >=1.10
 
 executable haddocset
   main-is:             Main.hs
-  other-modules:       Documentation.Haddocset
+  other-modules:
+      Documentation.Haddocset
+      Documentation.Haddocset.Index
+      Documentation.Haddocset.Plist
   ghc-options:         -Wall -O2
   build-depends:       base                 >=4.6   && <4.9
                      , ghc                  >=7.4   && <7.11


### PR DESCRIPTION
This PR doesn't contain any behavioral changes; only minor code reorg.

- All database access was moved to a single module to avoid passing raw connections around and ensure writes aren't performed without a transaction.
- Moved Plist to its own module.
