### PR TITLE
Fix table of contents linking

### DIFF
--- a/Documentation/Haddocset.hs
+++ b/Documentation/Haddocset.hs
@@ -145,10 +145,6 @@ copyHtml doc dst = do
                     | "file:///" `T.isPrefixOf` url -> Ts.TagOpen "a" (toAttr "href" (rebase . P.fromText $ T.drop 7 url) attr)
                     | "#"        `T.isPrefixOf` url -> Ts.TagOpen "a" (toAttr "href" (rebase $ addHash url dst) attr)
                     | otherwise                     -> Ts.TagOpen "a" (toAttr "href" (rebase . absp       $          url) attr)
-        | Ts.tagOpenLit "a" (Ts.anyAttrNameLit "name") tag =
-            let Ts.TagOpen _ attr = tag
-                hash = '#' `T.cons` Ts.fromAttrib "name" tag
-            in Ts.TagOpen "a" (toAttr "href" (rebase $ addHash hash dst) attr)
         | otherwise = tag
 
     addHash h file = P.dirname file P.</> case P.toText $ P.filename file of


### PR DESCRIPTION
haddocset currently rewrites,

    <a name="v:foo">foo</a>

To

    <a href="../$pkgname-1.2.3/SomeModule.html#v:foo" name="v:foo">foo</a>

This seems to mess with Dash's (at least in Dash 3) table of contents in the
bottom left part of the window. It expects to append the `name` to the URL so
it ends up with a double-encoded version. For example,

    criterion-1.1.0.0/Criterion.html#t:Benchmark%23t:Benchmark

The fix for this is simply to leave the `<a name>` tags alone.

Alternatively, [this version of ToC support](https://kapeli.com/docsets#tableofcontents) (which I assume is new) will have to be implemented.