### PR TITLE
Add support for pkgroot relative paths in conf files

### DIFF
--- a/Documentation/Haddocset.hs
+++ b/Documentation/Haddocset.hs
@@ -139,11 +139,17 @@ readDocInfoFile pifile = doesDirectoryExist pifile >>= \isDir ->
                 | otherwise -> Just $
                     DocInfo
                         (sourcePackageId a)
-                        (haddockInterfaces a)
-                        (haddockHTMLs a)
+                        (map expandPkgRoot (haddockInterfaces a))
+                        (map expandPkgRoot (haddockHTMLs a))
                         (exposed a)
 
             ParseOk _  _  -> Nothing
+  where
+    -- drop the package.conf directory: pkgroot/package.conf.d/foo.conf -> pkgroot
+    pkgroot = takeDirectory . takeDirectory $ pifile
+    expandPkgRoot path = case splitPath path of
+        "${pkgroot}/":rest -> joinPath (pkgroot : rest)
+        _ -> path
 
 copyHtml :: DocFile -> FilePath -> IO ()
 copyHtml doc dst = do


### PR DESCRIPTION
pkgroot relative paths are paths prefixed with `${pkgroot}`, which is
resolved to the directory in which the package config directory resides.

OSX ghc installations uses this to allow for ghc to be installed as an
application bundle. Therefore support for this is necessary in order to
pull in documentation for base packages on OSX.