### PR TITLE
Patch to skip scan for global packages

### DIFF
--- a/Documentation/Haddocset.hs
+++ b/Documentation/Haddocset.hs
@@ -88,6 +88,7 @@ listDirectory :: FilePath -> IO [FilePath]
 listDirectory p = map (p </>) . filter (`notElem` [".", ".."]) <$> getDirectoryContents p
 
 globalPackageDirectories :: FilePath -> IO [FilePath]
+globalPackageDirectories ""    = return []
 globalPackageDirectories hcPkg = do
     ds <- map init . filter isPkgDBLine . lines <$>
         readProcess hcPkg ["list", "--global"] ""

--- a/Main.hs
+++ b/Main.hs
@@ -41,7 +41,7 @@ createCommand o = do
   withSearchIndex (optTarget o </> "Contents/Resources/docSet.dsidx") $ \idx -> do
 
     globalDirs <- globalPackageDirectories (optHcPkg o)
-    unless (optQuiet o) $ do
+    unless ((null globalDirs) || optQuiet o) $ do
         putStr "    Global package directory: "
         putStr (head globalDirs)
         if length globalDirs > 1


### PR DESCRIPTION
With this PR you can specify `--hc-pkg ""` and haddocset will not import any global packages. This is useful when generating a docset for specific set of packages.

See https://gist.github.com/erantapaa/987d44dca7ee2e919dae for the work-around I had to do to generate a docset for `ghc-7.10.2` without this patch.

Let me know if there is another way to do this.