### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Use with stack
 ---
 
 ```
-$ stack exec -- haddocset create target.docset
+$ stack exec -- haddocset -t target.docset create
 $ stack build --haddock
 $ stack exec -- haddocset -t target.docset add $(stack path --local-pkg-db)/*.conf 
 ```


### PR DESCRIPTION
`haddocset create target.docset` is not a valid call and returns in an error