### PR TITLE
Bumped bounds to newer versions

### DIFF
--- a/haddocset.cabal
+++ b/haddocset.cabal
@@ -22,7 +22,7 @@ executable haddocset
   ghc-options:         -Wall -O2
   build-depends:       base                 >=4.6   && <4.9
                      , ghc                  >=7.4   && <7.11
-                     , optparse-applicative >=0.11  && <0.12
+                     , optparse-applicative >=0.11  && <0.13
                      , conduit              >=1.0   && <1.3
                      , conduit-extra        >=1.1   && <1.2
                      , tagsoup              >=0.13  && <1.4
@@ -36,7 +36,7 @@ executable haddocset
                      , exceptions           >=0.6   && <0.9
                      , resourcet            >=1.1   && <1.2
                      , mtl                  >=2.0   && <2.3
-                     , http-types           >=0.8   && <0.9
+                     , http-types           >=0.8   && <0.10
   if impl(ghc >= 7.8)
     build-depends:     haddock-api          >=2.15
   else


### PR DESCRIPTION
optparse-applicative and http-types were bumped up to use the stack LTS 4.0 versions.